### PR TITLE
Unpin setuptools for Python>=3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,11 @@ jobs:
         if: ${{ matrix.juju == '2.9' }}
         run: |
           echo "TEST_CONSTRAINTS_FILE=constraints-juju29.txt" >> $GITHUB_ENV
+      - name: Constrain Tox Environment for juju 3.x
+        if: ${{ matrix.juju == '3' }}
+        run: |
+          echo "TEST_JUJU3=1" >> $GITHUB_ENV
+          echo "TEST_CONSTRAINTS_FILE=constraints-juju3.txt" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ setenv =
   CHARM_LAYERS_DIR=/tmp/charm-builds/_tmp/layers
 passenv =
   HOME
+  TEST_*
 commands =
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal
     /bin/rm -rf /tmp/charm-builds/_tmp /tmp/charm-builds/minimal-binary-wheels

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -30,7 +30,8 @@ setuptools<62.2.0;python_version >= '3.8' and python_version<'3.12'
 setuptools>=62.2.0;python_version >= '3.12'
 setuptools-scm<=1.17.0;python_version < '3.8'
 # https://github.com/pypa/setuptools_scm/issues/722
-setuptools-scm<7;python_version >= '3.8'
+setuptools-scm<7;python_version >= '3.8' and python_version < '3.12'
+setuptools-scm>=7;python_version >= '3.12'
 flit_core<4.0.0;python_version >= '3.8'
 flit_scm<=1.7.0;python_version >= '3.8'
 charmhelpers>=0.4.0,<2.0.0
@@ -41,5 +42,5 @@ wheel<1.0;python_version >= '3.8'
 netaddr<=0.7.19
 
 # https://github.com/python-trio/sniffio/pull/49
-anyio<3.7.0;python_version >= '3.8'
-sniffio<1.3.1  # 1.3.1 requires setuptools>=64
+anyio<3.7.0;python_version >= '3.8' and python_version < '3.12'
+sniffio<1.3.1;python_version < '3.12'  # 1.3.1 requires setuptools>=64

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -26,7 +26,8 @@ MarkupSafe<2.2.0;python_version >= '3.7' # newer pythons
 
 setuptools<42;python_version < '3.8'
 # https://github.com/juju-solutions/layer-basic/issues/201
-setuptools<62.2.0;python_version >= '3.8'
+setuptools<62.2.0;python_version >= '3.8' and python_version<'3.12'
+setuptools>=62.2.0;python_version >= '3.12'
 setuptools-scm<=1.17.0;python_version < '3.8'
 # https://github.com/pypa/setuptools_scm/issues/722
 setuptools-scm<7;python_version >= '3.8'


### PR DESCRIPTION
The version of setuptools pinned by the wheelhouse is incompatible with python 3.12, to avoid breaking old charms, this patch unpins setuptools only for python>=3.12

Fixes the following error at build time:

      File "/tmp/pip-download-gg1zdrmr/setuptools_ebd74bdeeaf0421480a69f5448330f5e/setuptools/__init__.py", line 16, in <module>
        import setuptools.version
      File "/tmp/pip-download-gg1zdrmr/setuptools_ebd74bdeeaf0421480a69f5448330f5e/setuptools/version.py", line 1, in <module>
        import pkg_resources
      File "/tmp/pip-download-gg1zdrmr/setuptools_ebd74bdeeaf0421480a69f5448330f5e/pkg_resources/__init__.py", line 2191, in <module>
        register_finder(pkgutil.ImpImporter, find_on_path)
                        ^^^^^^^^^^^^^^^^^^^
    AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?