### PR TITLE
sniffio is pulled in for anyio, it is not needed otherwise so make it match

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -43,4 +43,5 @@ netaddr<=0.7.19
 
 # https://github.com/python-trio/sniffio/pull/49
 anyio<3.7.0;python_version >= '3.8' and python_version < '3.12'
-sniffio<1.3.1;python_version < '3.12'  # 1.3.1 requires setuptools>=64
+# sniffio is pulled in for anyio, it is not needed otherwise so make it match
+sniffio<1.3.1;python_version >= '3.8' and python_version < '3.12'  # 1.3.1 requires setuptools>=64


### PR DESCRIPTION
Fixes https://github.com/canonical/layer-basic/issues/223