### PR TITLE
Pinning pbr<6.1.1 so it continues to use setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Setup Python
       uses: actions/setup-python@v5
+      env:
+        PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
       with:
         python-version: ${{ matrix.python }}
     - name: Install Dependencies

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -46,3 +46,7 @@ anyio<3.7.0;python_version >= '3.8' and python_version < '3.12'
 # sniffio is pulled in for anyio, it is not needed otherwise so make it match
 sniffio<1.3.1;python_version >= '3.8' and python_version < '3.12'  # 1.3.1 requires setuptools>=64
 immutables<0.16;python_version < '3.8' # >=0.16 requires setuptools>=42
+
+
+# https://bugs.launchpad.net/charm-gcp-integrator/+bug/2098017
+pbr<6.1.1


### PR DESCRIPTION
Pinning pbr<6.1.1 to deal with install hook issue on reactive charms that depend on `charmhelpers`.

Layer basic pins setuptools to a version which cannot install pbr.

```sh
2025-02-11 21:18:08 DEBUG unit.openstack-integrator/0.install logger.go:60 Processing ./wheelhouse/pbr-6.1.1.tar.gz
2025-02-11 21:18:08 DEBUG unit.openstack-integrator/0.install logger.go:60   Installing build dependencies: started
2025-02-11 21:18:09 DEBUG unit.openstack-integrator/0.install logger.go:60   Installing build dependencies: finished with status 'error'
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   error: subprocess-exited-with-error
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   × pip subprocess to install build dependencies did not run successfully.
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   │ exit code: 1
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   ╰─> [4 lines of output]
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60       Looking in links: wheelhouse
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60       Ignoring setuptools: markers 'python_version < "3.7"' don't match your environment
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60       ERROR: Could not find a version that satisfies the requirement setuptools>=64.0.0 (from versions: 62.1.0)
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60       ERROR: No matching distribution found for setuptools>=64.0.0
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60       [end of output]
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   note: This error originates from a subprocess, and is likely not a problem with pip.
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 error: subprocess-exited-with-error
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 × pip subprocess to install build dependencies did not run successfully.
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 │ exit code: 1
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 ╰─> See above for output.
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 note: This error originates from a subprocess, and is likely not a problem with pip.
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 Traceback (most recent call last):
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   File "/var/lib/juju/agents/unit-openstack-integrator-0/charm/hooks/install", line 8, in <module>
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60     basic.bootstrap_charm_deps()
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   File "/var/lib/juju/agents/unit-openstack-integrator-0/charm/lib/charms/layer/basic.py", line 224, in bootstrap_charm_deps
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60     check_call([pip, 'install', '-U', reinstall_flag, '--no-index',
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60   File "/usr/lib/python3.10/subprocess.py", line 369, in check_call
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60     raise CalledProcessError(retcode, cmd)
2025-02-11 21:18:09 WARNING unit.openstack-integrator/0.install logger.go:60 subprocess.CalledProcessError: Command '['/var/lib/juju/agents/unit-openstack-integrator-0/.venv/bin/pip', 'install', '-U', '--force-reinstall', '--no-index', '--no-cache-dir', '-f', 'wheelhouse', 'marshmallow-enum==1.5.1', 'tomli==2.2.1', 'tenacity==9.0.0', 'Cython==0.29.37', 'sniffio==1.3.0', 'marshmallow==3.22.0', 'flit-core==3.10.1', 'cached-property==2.0.1', 'pbr==6.1.1', 'websocket-client==1.8.0', 'ops-reactive-interface==1.1.0', 'pyyaml==6.0.2', 'str2bool==1.1', 'charmhelpers==1.2.1', 'jinja2==3.1.5', 'ops==2.18.1', 'idna==3.10', 'loadbalancer-interface==1.2.0', 'anyio==3.6.2', 'flit-scm==1.7.0', 'packaging==24.2', 'netaddr==0.7.19', 'charms-reactive==1.5.3', 'pyaml==21.10.1']' returned non-zero exit status 1.
```